### PR TITLE
Add shared footer and update privacy policy

### DIFF
--- a/404.html
+++ b/404.html
@@ -34,5 +34,8 @@
       </div>
     </div>
   </main>
+  <footer class="footer">
+    <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
+  </footer>
 </body>
 </html>

--- a/Get-access/index.html
+++ b/Get-access/index.html
@@ -1942,6 +1942,10 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 </script>
 
-  <script src="/co-header.js"></script>
+  <footer class="footer">
+  <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
+</footer>
+
+<script src="/co-header.js"></script>
 </body>
 </html>

--- a/How_it_works/index.html
+++ b/How_it_works/index.html
@@ -711,6 +711,10 @@
     });
   </script>
   
-  <script src="/co-header.js"></script>
+  <footer class="footer">
+  <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
+</footer>
+
+<script src="/co-header.js"></script>
 </body>
 </html>

--- a/Intel/index.html
+++ b/Intel/index.html
@@ -463,6 +463,10 @@
   <script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
   <script src="/assets/js/market-navigator.js"></script>
   <script src="/assets/js/intel.js"></script>
-  <script src="/co-header.js"></script>
+  <footer class="footer">
+  <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
+</footer>
+
+<script src="/co-header.js"></script>
 </body>
 </html>

--- a/Speak_with_us/index.html
+++ b/Speak_with_us/index.html
@@ -931,6 +931,10 @@
       });
     });
   </script>
-  <script src="/co-header.js"></script>
+  <footer class="footer">
+  <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
+</footer>
+
+<script src="/co-header.js"></script>
 </body>
 </html>

--- a/Why_Crown_&_Oak/index.html
+++ b/Why_Crown_&_Oak/index.html
@@ -588,18 +588,7 @@
       background: rgba(212,180,90,0.95);
       transform: translateY(-4px);
     }
-    
-    /* FOOTER */
-    .footer {
-      padding: 40px 0;
-      text-align: center;
-      border-top: 1px solid rgba(212,180,90,0.1);
-    }
-    .footer-text {
-      font-size: 14px;
-      color: rgba(212,180,90,0.6);
-    }
-    
+        
     @media (max-width: 768px) {
       .pillars-grid { grid-template-columns: 1fr; }
       .content-section { padding: 40px 20px; }

--- a/co-shared.css
+++ b/co-shared.css
@@ -21,3 +21,7 @@
 @media (max-width:1024px){.nav-toggle{display:block}.nav-menu{position:fixed;top:0;right:-100%;width:300px;height:100vh;background:rgba(10,12,20,.98);backdrop-filter:saturate(180%) blur(10px);flex-direction:column;align-items:flex-end;padding:100px 30px 30px;transition:right .4s;overflow-y:auto;z-index:1000}.nav-open .nav-menu{right:0}.nav-list{flex-direction:column;gap:20px;align-items:flex-end;text-align:right}.nav-cta .cta-btn{width:100%;padding:12px 30px}}
 @media (max-width:768px){.nav-link{font-size:clamp(12px,2vw,16px)}.cta-btn{font-size:clamp(14px,2vw,18px);padding:10px 24px}}
 body.page-with-fixed-header{padding-top:120px}
+
+/* FOOTER */
+.footer{padding:40px 0;text-align:center;border-top:1px solid rgba(212,180,90,0.1)}
+.footer-text{font-size:14px;color:rgba(212,180,90,0.6)}

--- a/index.html
+++ b/index.html
@@ -204,6 +204,10 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 </script>
 
+<footer class="footer">
+  <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
+</footer>
+
 <!-- Shared header script (includes canonical/redirect logic you added) -->
 <script src="/co-header.js"></script>
 </body>

--- a/privacy_policy/index.html
+++ b/privacy_policy/index.html
@@ -1,26 +1,42 @@
-PRIVACY POLICY
-
-A Legal Disclaimer
-
-The explanations and information provided on this page are only general and high-level explanations and information on how to write your own document of
-a Privacy Policy. You should not rely on this article as legal advice or as recommendations regarding what you should actually do, because we cannot know in
-advance what are the specific privacy policies you wish to establish between your business and your customers and visitors. We recommend that you seek legal
-advice to help you understand and to assist you in the creation of your own Privacy Policy.
-
-Privacy Policy - The Basics
-
-Having said that, a privacy policy is a statement that discloses some or all of the ways a website collects, uses, discloses, processes, and manages the data of its
-visitors and customers. It usually also includes a statement regarding the website's commitment to protecting its visitors' or customers' privacy, and an
-explanation about the different mechanisms the website is implementing in order to protect privacy.
-
-Different jurisdictions have different legal obligations of what must be included in a Privacy Policy. You are responsible to make sure you are following the
-relevant legislation to your activities and location.
-
-What to Include in the Privacy Policy
-
-Generally speaking, a Privacy Policy often addresses these types of issues: the types of information the website is collecting and the manner in which it collects
-the data; an explanation about why is the website collecting these types of information; what are the website's practices on sharing the information with third
-parties; ways in which your visitors an customers can exercise their rights according to the relevant privacy legislation; the specific practices regarding minors'
-data collection; and much much more.
-
-To learn more about this, check out our article "Creating a Privacy Policy".
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacy Policy - Crown & Oak Capital</title>
+  <link rel="stylesheet" href="/co-shared.css">
+</head>
+<body class="page-with-fixed-header">
+<header class="header" role="banner">
+  <div class="header-container">
+    <a href="/" class="logo" aria-label="Crown & Oak — Home">
+      <img src="/images/Logo.png" alt="Crown & Oak">
+    </a>
+    <button class="nav-toggle" aria-label="Toggle Navigation"><span></span><span></span><span></span></button>
+    <nav class="nav-menu" aria-label="Primary">
+      <ul class="nav-list">
+        <li><a data-slug="Why_Crown_&_Oak" href="/Why_Crown_&_Oak" class="nav-link">Why Crown &amp; Oak</a></li>
+        <li><a data-slug="How_it_works" href="/How_it_works" class="nav-link">How It Works</a></li>
+        <li><a data-slug="Intel" href="/Intel" class="nav-link">Intel</a></li>
+        <li><a data-slug="Speak_with_us" href="/Speak_with_us" class="nav-link">Speak With Us</a></li>
+      </ul>
+      <div class="nav-cta">
+        <a data-slug="Get-access" href="/Get-access" class="cta-btn">Request Access</a>
+      </div>
+    </nav>
+  </div>
+</header>
+<div class="overlay" aria-hidden="true"></div>
+<main style="max-width:800px;margin:120px auto;padding:40px 20px;">
+  <h1>Privacy Policy</h1>
+  <p>Crown & Oak Capital respects your privacy. This policy explains how we handle personal information collected through our website.</p>
+  <p>We collect personal data that you voluntarily provide, such as when requesting access or contacting us. We use this information to respond to inquiries and provide our services. We also gather limited analytics data to improve our site.</p>
+  <p>We do not sell your personal information. We may share data with service providers who support our operations, subject to confidentiality obligations.</p>
+  <p>If you have questions about this policy, please contact us through our <a href="/Speak_with_us/">contact page</a>.</p>
+</main>
+<footer class="footer">
+  <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
+</footer>
+<script src="/co-header.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- centralize footer styles in shared stylesheet
- add consistent footer across site pages
- replace placeholder privacy policy with structured content

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68ae6b3b13708323b2e93e5abf530663