### PR TITLE
Add Terms of Use link to footers across site

### DIFF
--- a/404.html
+++ b/404.html
@@ -36,7 +36,7 @@
   </main>
   <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 </body>
 </html>

--- a/Get-access/index.html
+++ b/Get-access/index.html
@@ -1944,7 +1944,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 
 <script src="/co-header.js"></script>

--- a/How_it_works/index.html
+++ b/How_it_works/index.html
@@ -713,7 +713,7 @@
   
   <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 
 <script src="/co-header.js"></script>

--- a/Intel/index.html
+++ b/Intel/index.html
@@ -465,7 +465,7 @@
   <script src="/assets/js/intel.js"></script>
   <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 
 <script src="/co-header.js"></script>

--- a/Speak_with_us/index.html
+++ b/Speak_with_us/index.html
@@ -933,7 +933,7 @@
   </script>
   <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 
 <script src="/co-header.js"></script>

--- a/Why_Crown_&_Oak/index.html
+++ b/Why_Crown_&_Oak/index.html
@@ -971,7 +971,7 @@
 
   <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 
   <script>

--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 
 <!-- Shared header script (includes canonical/redirect logic you added) -->

--- a/legal/terms-of-use.html
+++ b/legal/terms-of-use.html
@@ -102,7 +102,7 @@
 </main>
 <footer class="footer">
   <p class="footer-text">© 2025 Crown &amp; Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 <script src="/co-header.js"></script>
 </body>

--- a/privacy_policy/index.html
+++ b/privacy_policy/index.html
@@ -217,7 +217,7 @@
 </main>
 <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 <script src="/co-header.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Add "Terms of Use" link to footer navigation on all pages

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_b_68af29d8bc58832385b34939ba8ff35a