### PR TITLE
Add Fed rate report widget to Intel page

### DIFF
--- a/Intel/index.html
+++ b/Intel/index.html
@@ -316,6 +316,68 @@
       .viz-panel { grid-template-columns: 1fr; }
       .carousel { overflow-x: scroll; }
     }
+
+    /* — FED RATE WIDGET — */
+    .fed-widget {
+      background: #14161E;
+      border: 1px solid rgba(212,180,90,0.1);
+      border-radius: 8px;
+      padding: 30px;
+      box-shadow: 0 10px 30px rgba(0,0,0,0.4);
+      margin-bottom: 60px;
+    }
+    .fed-widget h2 {
+      font-family: 'Cormorant Garamond', serif;
+      font-size: 24px;
+      margin-bottom: 8px;
+      text-transform: uppercase;
+    }
+    .fed-widget .next-meeting {
+      font-size: 14px;
+      color: rgba(212,180,90,0.7);
+      margin-bottom: 20px;
+    }
+    .fed-widget .fed-content {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .fed-widget .fed-rate .label {
+      font-size: 14px;
+      color: rgba(212,180,90,0.7);
+    }
+    .fed-widget .fed-rate .rate {
+      font-size: 28px;
+      font-weight: 600;
+    }
+    .fed-widget button {
+      padding: 12px 24px;
+      background: transparent;
+      border: 1px solid #d4b45a;
+      color: #d4b45a;
+      text-transform: uppercase;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+    .fed-widget button:hover {
+      background: #d4b45a;
+      color: #0a0c14;
+    }
+    .fed-widget .fed-report {
+      margin-top: 20px;
+      background: #1A1C27;
+      border: 1px solid rgba(212,180,90,0.1);
+      border-radius: 8px;
+      padding: 20px;
+    }
+    .fed-widget .error {
+      background: #7b1d1d;
+      padding: 10px 15px;
+      border-radius: 4px;
+      margin-bottom: 15px;
+      color: #f2d6d6;
+    }
   </style>
   <link rel="stylesheet" href="/co-shared.css">
 </head>
@@ -357,7 +419,7 @@
   
 
   <div class="container">
-    
+    <div id="fed-widget-root"></div>
 
     <section class="summary">
       <ul>
@@ -460,6 +522,122 @@
     <button id="methodology-close">Close</button>
   </dialog>
 
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <script type="text/babel">
+    const { useState, useEffect } = React;
+
+    const FedWidget = () => {
+      const [fedRate, setFedRate] = useState("4.25% - 4.50%");
+      const [nextMeetingDate, setNextMeetingDate] = useState('September 17, 2025');
+      const [fedReport, setFedReport] = useState('');
+      const [loadingFed, setLoadingFed] = useState(false);
+      const [error, setError] = useState(null);
+
+      const fetchWithBackoff = async (url, options, retries = 5, delay = 1000) => {
+        try {
+          const response = await fetch(url, options);
+          if (!response.ok) {
+            throw new Error('HTTP error! status: ' + response.status);
+          }
+          return response.json();
+        } catch (err) {
+          if (retries > 0) {
+            console.warn('Fetch failed. Retrying in ' + delay + 'ms...');
+            await new Promise(res => setTimeout(res, delay));
+            return fetchWithBackoff(url, options, retries - 1, delay * 2);
+          } else {
+            throw err;
+          }
+        }
+      };
+
+      const formatMarkdown = (markdown) => {
+        let html = markdown.replace(/^#\s(.+)$/gm, '<h1>$1</h1>');
+        html = html.replace(/^##\s(.+)$/gm, '<h2><b>$1</b></h2>');
+        html = html.replace(/^###\s(.+)$/gm, '<h3><b>$1</b></h3>');
+        html = html.replace(/^####\s(.+)$/gm, '<h4><b>$1</b></h4>');
+        html = html.replace(/\n\n/g, '</p><p>');
+        html = html.replace(/\n/g, '<br/>');
+        html = html.replace(/\*\*(.+?)\*\*/g, '<b>$1</b>');
+        html = html.replace(/^\*\s(.+)$/gm, '<li>$1</li>');
+        html = html.replace(/^- (.*)$/gm, '<li>$1</li>');
+        if (!html.startsWith('<p>') && !html.startsWith('<h1>') && !html.startsWith('<h2>') && !html.startsWith('<h3>') && !html.startsWith('<h4>') && !html.startsWith('<li>')) {
+          html = '<p>' + html + '</p>';
+        }
+        return html;
+      };
+
+      useEffect(() => {
+        setNextMeetingDate('September 17, 2025');
+      }, []);
+
+      const fetchReport = async (prompt, setReport, setLoading) => {
+        setLoading(true);
+        setReport('');
+        setError(null);
+
+        const payload = {
+          contents: [{
+            parts: [{ text: prompt }]
+          }]
+        };
+
+        const apiKey = "";
+        const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=${apiKey}`;
+
+        try {
+          const result = await fetchWithBackoff(apiUrl, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload)
+          });
+          const text = result?.candidates?.[0]?.content?.parts?.[0]?.text;
+          if (text) {
+            setReport(formatMarkdown(text));
+          } else {
+            setError('Failed to get a report from Gemini. Please try again.');
+          }
+        } catch (err) {
+          console.error(err);
+          setError('An error occurred while fetching the report. Please check the console.');
+        } finally {
+          setLoading(false);
+        }
+      };
+
+      return (
+        <div className="fed-widget">
+          {error && <div className="error"><p className="font-bold">Error</p><p>{error}</p></div>}
+          <h2>Federal Funds Rate Target Range</h2>
+          <p className="next-meeting">Next FOMC Meeting: {nextMeetingDate !== null ? nextMeetingDate : 'Loading...'}</p>
+          <div className="fed-content">
+            <div className="fed-rate">
+              <p className="label">Next FOMC Rate</p>
+              <p className="rate">{fedRate}</p>
+            </div>
+            <button
+              onClick={() => {
+                const prompt = `Act as a financial analyst. Generate a concise report on the current Federal Funds Rate target range, including its historical context and its anticipated impact on commercial real estate financing and investment decisions. The current rate is ${fedRate}. Use a professional, but easy-to-understand tone. Format the response with a main title and clear subtitles using Markdown headings. Use a hyphen (-) for bullet points.`;
+                fetchReport(prompt, setFedReport, setLoadingFed);
+              }}
+              disabled={loadingFed}
+            >
+              {loadingFed ? 'Generating...' : 'Get Report'}
+            </button>
+          </div>
+          {fedReport && (
+            <div className="fed-report" dangerouslySetInnerHTML={{ __html: fedReport }} />
+          )}
+        </div>
+      );
+    };
+
+    ReactDOM.createRoot(document.getElementById('fed-widget-root')).render(<FedWidget />);
+  </script>
   <script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
   <script src="/assets/js/market-navigator.js"></script>
   <script src="/assets/js/intel.js"></script>


### PR DESCRIPTION
## Summary
- add themed Fed rate widget to Intel page top
- allow fetching Gemini-generated rate impact reports with backoff and markdown formatting

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68af3a2b70a883239ac5440e1c99bdf3