### PR TITLE
feat: add SMS terms page and disclosures

### DIFF
--- a/404.html
+++ b/404.html
@@ -36,7 +36,7 @@
   </main>
   <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/sms-terms/">SMS Terms</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 </body>
 </html>

--- a/Get-access/index.html
+++ b/Get-access/index.html
@@ -1737,6 +1737,7 @@
         </div>
         
         <div class="submit-container" id="final-submit" style="display: none;">
+          <p>By submitting, you agree to receive SMS messages from Crown and Oak Capital Advisors regarding investment opportunities and related updates. <strong>Message frequency varies. Message &amp; data rates may apply.</strong> Reply <strong>STOP</strong> to opt out, <strong>HELP</strong> for help. <a href="/privacy_policy/" target="_blank" rel="noopener">Privacy Policy</a> • <a href="/sms-terms/" target="_blank" rel="noopener">SMS Terms</a></p>
           <button type="submit" class="btn btn-submit">SUBMIT INVESTMENT CRITERIA</button>
           <p class="privacy-note">
             All information is treated with absolute confidentiality. Upon submission, a Crown & Oak Capital advisor will contact you within 24 hours to confirm receipt and discuss potential opportunities. By submitting, you acknowledge our confidentiality protocols and privacy policy.
@@ -1944,7 +1945,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/sms-terms/">SMS Terms</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 
 <script src="/co-header.js"></script>

--- a/How_it_works/index.html
+++ b/How_it_works/index.html
@@ -713,7 +713,7 @@
   
   <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/sms-terms/">SMS Terms</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 
 <script src="/co-header.js"></script>

--- a/Intel/index.html
+++ b/Intel/index.html
@@ -151,6 +151,11 @@
   <button id="methodology-close">Close</button>
 </dialog>
 
+<footer class="footer">
+  <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/sms-terms/">SMS Terms</a> | <a href="/accessability/">Accessibility</a></p>
+</footer>
+
 <script>
 (async function(){
   const res = await fetch('/data/ticker.json', { cache:'no-store' });

--- a/Speak_with_us/index.html
+++ b/Speak_with_us/index.html
@@ -815,6 +815,7 @@
           <textarea id="message" placeholder="Please share any additional information that would help us prepare for our conversation."></textarea>
         </div>
         
+        <p>By submitting, you agree to receive SMS messages from Crown and Oak Capital Advisors regarding investment opportunities and related updates. <strong>Message frequency varies. Message &amp; data rates may apply.</strong> Reply <strong>STOP</strong> to opt out, <strong>HELP</strong> for help. <a href="/privacy_policy/" target="_blank" rel="noopener">Privacy Policy</a> • <a href="/sms-terms/" target="_blank" rel="noopener">SMS Terms</a></p>
         <button type="submit" class="submit-btn">SUBMIT REQUEST</button>
       </form>
     </div>
@@ -933,7 +934,7 @@
   </script>
   <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/sms-terms/">SMS Terms</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 
 <script src="/co-header.js"></script>

--- a/Why_Crown_&_Oak/index.html
+++ b/Why_Crown_&_Oak/index.html
@@ -971,7 +971,7 @@
 
   <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/sms-terms/">SMS Terms</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 
   <script>

--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/sms-terms/">SMS Terms</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 
 <!-- Shared header script (includes canonical/redirect logic you added) -->

--- a/legal/terms-of-use.html
+++ b/legal/terms-of-use.html
@@ -102,7 +102,7 @@
 </main>
 <footer class="footer">
   <p class="footer-text">© 2025 Crown &amp; Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/sms-terms/">SMS Terms</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 <script src="/co-header.js"></script>
 </body>

--- a/privacy_policy/index.html
+++ b/privacy_policy/index.html
@@ -183,6 +183,10 @@
   <h2>14) Children’s Privacy</h2>
   <p>The Site is not intended for individuals under 16 (or the minimum age required in your jurisdiction). We do not knowingly collect such data. If you believe a minor has provided information, contact us to delete it.</p>
 
+  <!-- SMS Communications (A2P 10DLC) -->
+  <h2>SMS Communications</h2>
+  <p>If you opt in to receive text messages from Crown &amp; Oak Capital Advisors, we will use your phone number to send messages related to investment opportunities, meeting reminders, and account or portal notifications. <strong>SMS consent is not shared with third parties or affiliates</strong> other than service providers that send messages on our behalf, and they may not use your number for their own purposes. Message frequency varies. Message &amp; data rates may apply. Reply <strong>STOP</strong> to opt out, <strong>HELP</strong> for help. Contact us at +1-646-964-9686 or <a href="mailto:alec@crownandoakcapital.com">alec@crownandoakcapital.com</a>. See our <a href="/sms-terms/">SMS Terms &amp; Conditions</a> for details.</p>
+
   <h2>15) Changes to This Policy</h2>
   <p>We may update this Policy from time to time. The Effective Date above reflects the latest version. Material changes will be posted on this page and, where appropriate, notified to you.</p>
 
@@ -217,7 +221,7 @@
 </main>
 <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/sms-terms/">SMS Terms</a> | <a href="/accessability/">Accessibility</a></p>
 </footer>
 <script src="/co-header.js"></script>
 </body>

--- a/sms-terms/index.html
+++ b/sms-terms/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>SMS Terms & Conditions - Crown & Oak Capital</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@400;500;600&family=Montserrat:wght@300;400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/co-shared.css">
+  <style>
+    body{background:#0a0c14;color:#d4b45a;font-family:'Montserrat',sans-serif;line-height:1.6}
+    .policy-content{max-width:800px;margin:0 auto;padding:40px 20px}
+    h1{font-family:'Cormorant Garamond',serif;font-weight:500;font-size:clamp(24px,4vw,40px);text-align:center;margin-bottom:30px;text-transform:uppercase;letter-spacing:2px}
+    h2{font-family:'Cormorant Garamond',serif;font-weight:500;margin:24px 0 10px;font-size:clamp(18px,2.6vw,26px)}
+    p,li{font-size:15px;color:rgba(212,180,90,.9)}
+    a{color:#d4b45a}
+    ul{padding-left:18px}
+    code{background:rgba(212,180,90,.1);padding:2px 6px;border-radius:6px}
+  </style>
+</head>
+<body class="page-with-fixed-header">
+<header class="header" role="banner">
+  <div class="header-container">
+    <a href="/" class="logo" aria-label="Crown & Oak — Home">
+      <img src="/images/Logo.png" alt="Crown & Oak">
+    </a>
+    <button class="nav-toggle" aria-label="Toggle Navigation"><span></span><span></span><span></span></button>
+    <nav class="nav-menu" aria-label="Primary">
+      <ul class="nav-list">
+        <li><a data-slug="Why_Crown_&_Oak" href="/Why_Crown_&_Oak" class="nav-link">Why Crown &amp; Oak</a></li>
+        <li><a data-slug="How_it_works" href="/How_it_works" class="nav-link">How It Works</a></li>
+        <li><a data-slug="Intel" href="/Intel" class="nav-link">Intel</a></li>
+        <li><a data-slug="Speak_with_us" href="/Speak_with_us" class="nav-link">Speak With Us</a></li>
+      </ul>
+      <div class="nav-cta">
+        <a data-slug="Get-access" href="/Get-access" class="cta-btn">Request Access</a>
+      </div>
+    </nav>
+  </div>
+</header>
+<div class="overlay" aria-hidden="true"></div>
+
+<main class="policy-content">
+  <h1>SMS Terms &amp; Conditions</h1>
+
+  <p><strong>Provider/Brand:</strong> Crown and Oak Capital Advisors (a brand of Salesmax LLC)</p>
+  <p><strong>Number(s):</strong> <!-- add your RingCentral SMS-enabled number(s) here --> </p>
+
+  <h2>1) Program Description</h2>
+  <p>By opting in, you agree to receive SMS messages related to off-market opportunities, meeting reminders/confirmations, document access notifications, and account or preference updates.</p>
+
+  <h2>2) Opt-In</h2>
+  <p>You may opt in via our web forms, documented verbal consent with our team, or by texting <strong>START</strong> to our number.</p>
+
+  <h2>3) Message Frequency</h2>
+  <p><strong>Message frequency may vary.</strong></p>
+
+  <h2>4) Cost</h2>
+  <p><strong>Message and data rates may apply.</strong></p>
+
+  <h2>5) Opt-Out</h2>
+  <p>Text <strong>STOP</strong> at any time to stop receiving messages. You will receive a final confirmation SMS.</p>
+
+  <h2>6) Help</h2>
+  <p>Text <strong>HELP</strong> for assistance or contact us at +1-646-964-9686 or <a href="mailto:alec@crownandoakcapital.com">alec@crownandoakcapital.com</a>.</p>
+
+  <h2>7) Carriers</h2>
+  <p>Wireless carriers are not liable for delayed or undelivered messages.</p>
+
+  <h2>8) Eligibility</h2>
+  <p>Must be 18+ to subscribe.</p>
+
+  <h2>9) Privacy</h2>
+  <p>Personal information is handled per our <a href="/privacy_policy/">Privacy Policy</a>. <strong>SMS consent is not shared with third parties.</strong></p>
+
+  <h2>10) Changes</h2>
+  <p>We may update these terms; the effective date will be posted on this page.</p>
+
+  <h2>11) Contact</h2>
+  <p>Crown &amp; Oak Capital, 745 Fifth Avenue, 5th Floor, New York, NY 10151; +1-646-964-9686; <a href="mailto:alec@crownandoakcapital.com">alec@crownandoakcapital.com</a></p>
+</main>
+
+<footer class="footer">
+  <p class="footer-text">© 2025 Crown &amp; Oak Capital. All rights reserved.</p>
+  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/sms-terms/">SMS Terms</a> | <a href="/accessability/">Accessibility</a></p>
+</footer>
+
+<script src="/co-header.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add SMS Terms & Conditions page
- link SMS Terms in site footers and add consent text to forms
- document SMS messaging practices in privacy policy

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68af58013f9c83239be31d0af488039c