### PR TITLE
Normalize footer links and add SMS disclosure

### DIFF
--- a/Get-access/index.html
+++ b/Get-access/index.html
@@ -1737,8 +1737,13 @@
         </div>
         
         <div class="submit-container" id="final-submit" style="display: none;">
-          <p>By submitting, you agree to receive SMS messages from Crown and Oak Capital Advisors regarding investment opportunities and related updates. Message frequency varies. Message &amp; data rates may apply. Reply STOP to opt out, HELP for help. Privacy: <a href="/privacy_policy/" target="_blank" rel="noopener">/privacy_policy/</a> • SMS Terms: <a href="/sms-terms/" target="_blank" rel="noopener">/sms-terms/</a>.</p>
           <button type="submit" class="btn btn-submit">SUBMIT INVESTMENT CRITERIA</button>
+          <p class="legal-copy">
+            By submitting, you agree to receive SMS messages from Crown &amp; Oak Capital Advisors.
+            Message frequency may vary. Message &amp; data rates may apply.
+            Text HELP for help. Reply STOP to opt out.
+            See our <a href="/privacy_policy/">Privacy Policy</a> and <a href="/sms-terms/">SMS Terms</a>.
+          </p>
           <p class="privacy-note">
             All information is treated with absolute confidentiality. Upon submission, a Crown & Oak Capital advisor will contact you within 24 hours to confirm receipt and discuss potential opportunities. By submitting, you acknowledge our confidentiality protocols and privacy policy.
           </p>
@@ -1945,7 +1950,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/sms-terms/">SMS Terms</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links">
+    <a href="/privacy_policy/">Privacy Policy</a> |
+    <a href="/sms-terms/">SMS Terms</a> |
+    <a href="/legal/terms-of-use.html">Terms of Use</a> |
+    <a href="/accessability/">Accessibility</a>
+  </p>
 </footer>
 
 <script src="/co-header.js"></script>

--- a/How_it_works/index.html
+++ b/How_it_works/index.html
@@ -713,7 +713,12 @@
   
   <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/sms-terms/">SMS Terms</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links">
+    <a href="/privacy_policy/">Privacy Policy</a> |
+    <a href="/sms-terms/">SMS Terms</a> |
+    <a href="/legal/terms-of-use.html">Terms of Use</a> |
+    <a href="/accessability/">Accessibility</a>
+  </p>
 </footer>
 
 <script src="/co-header.js"></script>

--- a/Speak_with_us/index.html
+++ b/Speak_with_us/index.html
@@ -815,8 +815,13 @@
           <textarea id="message" placeholder="Please share any additional information that would help us prepare for our conversation."></textarea>
         </div>
         
-        <p>By submitting, you agree to receive SMS messages from Crown and Oak Capital Advisors regarding investment opportunities and related updates. Message frequency varies. Message &amp; data rates may apply. Reply STOP to opt out, HELP for help. Privacy: <a href="/privacy_policy/" target="_blank" rel="noopener">/privacy_policy/</a> • SMS Terms: <a href="/sms-terms/" target="_blank" rel="noopener">/sms-terms/</a>.</p>
         <button type="submit" class="submit-btn">SUBMIT REQUEST</button>
+        <p class="legal-copy">
+          By submitting, you agree to receive SMS messages from Crown &amp; Oak Capital Advisors.
+          Message frequency may vary. Message &amp; data rates may apply.
+          Text HELP for help. Reply STOP to opt out.
+          See our <a href="/privacy_policy/">Privacy Policy</a> and <a href="/sms-terms/">SMS Terms</a>.
+        </p>
       </form>
     </div>
     
@@ -934,7 +939,12 @@
   </script>
   <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/sms-terms/">SMS Terms</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links">
+    <a href="/privacy_policy/">Privacy Policy</a> |
+    <a href="/sms-terms/">SMS Terms</a> |
+    <a href="/legal/terms-of-use.html">Terms of Use</a> |
+    <a href="/accessability/">Accessibility</a>
+  </p>
 </footer>
 
 <script src="/co-header.js"></script>

--- a/Why_Crown_&_Oak/index.html
+++ b/Why_Crown_&_Oak/index.html
@@ -971,7 +971,12 @@
 
   <footer class="footer">
   <p class="footer-text">© 2025 Crown & Oak Capital. All rights reserved.</p>
-  <p class="footer-links"><a href="/privacy_policy/">Privacy Policy</a> | <a href="/sms-terms/">SMS Terms</a> | <a href="/legal/terms-of-use.html">Terms of Use</a> | <a href="/accessability/">Accessibility</a></p>
+  <p class="footer-links">
+    <a href="/privacy_policy/">Privacy Policy</a> |
+    <a href="/sms-terms/">SMS Terms</a> |
+    <a href="/legal/terms-of-use.html">Terms of Use</a> |
+    <a href="/accessability/">Accessibility</a>
+  </p>
 </footer>
 
   <script>


### PR DESCRIPTION
## Summary
- Add SMS disclosure below submit buttons on Get-access and Speak_with_us forms
- Standardize four-link footer across content pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68af8a49907c8323a35e02daa99ea3ab